### PR TITLE
single server, smaller image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,14 @@
-FROM node:jessie
+FROM node:lts-jessie-slim
 EXPOSE 8080/tcp
-EXPOSE 3000/tcp
 
-RUN mkdir -p /usr/local/app
-WORKDIR /usr/local/app/
-COPY package.json package-lock.json /usr/local/app/
-RUN npm install
+RUN mkdir -p /usr/local/app/release/upperz
 
-RUN mkdir -p /usr/local/app/backend/release
-WORKDIR /usr/local/app/backend
-
-COPY upperz-backend/package.json /usr/local/app/backend/
-COPY upperz-backend/package-lock.json /usr/local/app/backend/
-COPY upperz-backend/portico*.tgz /usr/local/app/backend/
-COPY upperz-backend/release/ /usr/local/app/backend/release/
-RUN npm install
-
-RUN mkdir -p /usr/local/app/frontend/
-WORKDIR /usr/local/app/frontend
-
-COPY upperz-frontend/package.json /usr/local/app/frontend/
-COPY upperz-frontend/package-lock.json /usr/local/app/frontend/
-COPY upperz-frontend/src/ /usr/local/app/frontend/src/
-COPY upperz-frontend/public/ /usr/local/app/frontend/public/
-RUN npm install
+COPY upperz-backend/pack*.json /usr/local/app/
+COPY upperz-backend/portico*.tgz /usr/local/app/
+COPY upperz-backend/release/ /usr/local/app/release/
+COPY upperz-frontend/build/ /usr/local/app/release/upperz/
 
 WORKDIR /usr/local/app/
-CMD [ "npm", "run", "start:app" ]
+RUN npm install
+WORKDIR /usr/local/app/release
+CMD [ "node", "upperz-server.js" ]

--- a/README.md
+++ b/README.md
@@ -12,17 +12,8 @@ $ npm run docker-compose:up
 
 ```
 
-### testing
-
-```
-$ curl -s http://localhost:8080/ | jq
-  {
-    "status": "OK"
-  }
-```
-
 ### use
 
-Browse to http://localhost:3000
+Browse to http://localhost:8080
 
 ![upperz Demo](upperz.gif?raw=true "upperz")

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "scripts": {
     "clean": "rimraf upperz-frontend upperz-backend && npm-run-all -s clean:docker-image",
-    "build": "npm-run-all -s get:frontend get:backend build:backend build:docker-image",
+    "build": "npm-run-all -s get:frontend get:backend build:backend build:frontend inject:frontend build:docker-image",
     "build:docker-image": "docker build . -t tadalabs/upperz:latest",
     "docker-compose:up": "docker-compose up",
     "docker-compose:down": "docker-compose down",
@@ -28,9 +28,8 @@
     "get:frontend": "git clone https://github.com/tadalabs/upperz-frontend.git",
     "get:backend": "git clone https://github.com/tadalabs/upperz-backend.git",
     "build:backend": "cd upperz-backend && npm install && npm run build:api",
-    "start:backend": "cd /usr/local/app/backend/release && node api-server.js",
-    "start:frontend": "cd /usr/local/app/frontend && npm run start",
-    "start:app": "npm-run-all --parallel start:backend start:frontend"
+    "build:frontend": "cd upperz-frontend && npm install && npm run build",
+    "inject:frontend": "cd upperz-frontend/build && find . -depth -print | cpio -pdmv ../../upperz-backend/release/upperz"
   },
   "devDependencies": {
     "rimraf": "^2.6.3",


### PR DESCRIPTION
express now serves a static frontend, moved to jessie-slim-lts and refactored image creation to reduce docker image from 646MB to 303MB